### PR TITLE
Extras/ChickenAtomics: Ammonia propellant

### DIFF
--- a/Extras/ChickenAtomics/ChickenAtomics.cfg
+++ b/Extras/ChickenAtomics/ChickenAtomics.cfg
@@ -16,32 +16,20 @@
 //switching, more than two modes can't be added and in-flight switching can't be
 //disabled.
 
-// This two nodes allow reusing the same patch with and without SMURFF
-SMURFFCONFIG:NEEDS[!SMURFF]
-{
-}
 
-@SMURFFCONFIG:NEEDS[!SMURFF]
-{
-	%enginethrustfactor = 1
-	%lfofactor = 1
-}
-
-@PART[procedural*Liquid]:NEEDS[ProceduralParts&!RealFuels&!ModularFuelTanks]:AFTER[CryoTanks]
+@PART[procedural*Liquid]:NEEDS[ProceduralParts&!RealFuels&!ModularFuelTanks&!RationalResources]:AFTER[CryoTanks]
 {
 	@MODULE[TankContentSwitcher]
 	{
 		TANK_TYPE_OPTION
 		{
 			name = Ammonia
-			dryDensity = 0.1000
-			@dryDensity /= #$@SMURFFCONFIG/lfofactor$
+			dryDensity = 0.1089
 			costMultiplier = 0.75
 			RESOURCE
 			{
 				name = LqdAmmonia
-				// Accurate, but still placeholder value.
-				unitsPerKL = 880
+				unitsPerKL = 946.547
 			}
 		}
 	}

--- a/Extras/ChickenAtomics/ChickenAtomics.cfg
+++ b/Extras/ChickenAtomics/ChickenAtomics.cfg
@@ -80,7 +80,7 @@ SMURFFCONFIG:NEEDS[!SMURFF]
 			// and project rho predicts 100% thrust bonus
 	@MODULE[ModuleEnginesFX]:HAS[#engineID[LF]]
 	{
-		@engineID = Ammonia
+		//@engineID = Ammonia
 
 		@maxThrust *= 1.7
 		@maxThrust *= #$@SMURFFCONFIG/enginethrustfactor$
@@ -100,7 +100,7 @@ SMURFFCONFIG:NEEDS[!SMURFF]
 	}
 	@MODULE[MultiModeEngine]
 	{
-		@primaryEngineID = Ammonia
+		//@primaryEngineID = Ammonia
 		@primaryEngineModeDisplayName = Ammonia
 	}
 	// This one os OK, because we are not adding B9 and LiquidFuel really does not belong in NTR
@@ -112,7 +112,7 @@ SMURFFCONFIG:NEEDS[!SMURFF]
 {
 	@MODULE[ModuleEnginesFX]:HAS[#engineID[LOxAugmented]]
 	{
-		@engineID = Ammonia
+		//@engineID = Ammonia
 		@maxThrust = #$/MODULE[ModuleEnginesFX]:HAS[#engineID[LH2]]/maxThrust$
 		@maxThrust *= 1.8
 		@maxThrust *= #$@SMURFFCONFIG/enginethrustfactor$
@@ -132,14 +132,14 @@ SMURFFCONFIG:NEEDS[!SMURFF]
 	}
 	@MODULE[MultiModeEngine]
 	{
-		@secondaryEngineID = Ammonia
+		//@secondaryEngineID = Ammonia
 		@secondaryEngineModeDisplayName = Ammonia
 	}
 }
 
 // Add a LqdAmmonia mode
 
-@PART[ntr-gc-25-2]:NEEDS[!NTRsUseLF]:AFTER[zKerbalAtomics]
+@PART[ntr-gc-25-3]:NEEDS[!NTRsUseLF]:AFTER[zKerbalAtomics]
 {
 	@MODULE[ModuleEnginesFX]:HAS[@PROPELLANT[LqdHydrogen]]
 	{

--- a/Extras/ChickenAtomics/ChickenAtomics.cfg
+++ b/Extras/ChickenAtomics/ChickenAtomics.cfg
@@ -1,0 +1,174 @@
+//Chicken Gas Nuclear Thermal Rockets.
+
+//This patchset allows using liquid ammonia in NTRs. Dennis Nikitaev predicts
+//that ammonia propellant would result in 2x more thrust at 41% Isp. KSP-IE uses
+//1.4x thrust and 63% Isp. As a compromise, this patchset uses 1.7-1.8x thrust
+//and 60% Isp.
+
+//All multimode ntrs featuring LH2/LF switching are converted to LH2/NH3. Some
+//LA-NTRs are stripped of their oxidizer augmented mode and given NH3 modes
+//instead. And the Deliverance lightbulb rocket has been extended with ammonia
+//mode. The two later patches can be easily extended to other engines if desired.
+
+//Lastly, Ammonia configuration has been added to procedural liquid tank.
+
+//Due to incompatibility of ModuleSystemHeatFissionEngine with B9 based fuel
+//switching, more than two modes can't be added and in-flight switching can't be
+//disabled.
+
+// This two nodes allow reusing the same patch with and without SMURFF
+SMURFFCONFIG:NEEDS[!SMURFF]
+{
+}
+
+@SMURFFCONFIG:NEEDS[!SMURFF]
+{
+	%enginethrustfactor = 1
+	%lfofactor = 1
+}
+
+@PART[procedural*Liquid]:NEEDS[ProceduralParts&!RealFuels&!ModularFuelTanks]:AFTER[CryoTanks]
+{
+	@MODULE[TankContentSwitcher]
+	{
+		TANK_TYPE_OPTION
+		{
+			name = Ammonia
+			dryDensity = 0.1000
+			@dryDensity /= #$@SMURFFCONFIG/lfofactor$
+			costMultiplier = 0.75
+			RESOURCE
+			{
+				name = LqdAmmonia
+				// Accurate, but still placeholder value.
+				unitsPerKL = 880
+			}
+		}
+	}
+
+	@MODULE[ModuleCryoTank]
+	{
+		// in Ec per 1000 units per second
+		BOILOFFCONFIG
+		{
+			FuelName = LqdAmmonia
+			// in % per hr (placeholder values)
+			BoiloffRate = 0.005
+			CoolingCost = 0.02
+		}
+	}
+}
+
+// ntr-sc-0625-1 Eel			LH2
+// ntr-sc-125-1 Neptune		Aug *
+// ntr-sc-125-2 Stubber 	Aug
+// nuclearEngine Nerv			LH2/LF *
+// ntr-sc-25-1 Poseidon		Aug *
+// ntr-gc-25-1 Liberator	LH2
+// ntr-gc-25-2 Emancipator opLH2
+// ntr-gc-25-3 Deliverance LH2 *
+// restock-engine-cherenkov LH2/LF *
+// ntr-sc-375-1 Scylla	Aug *
+
+
+// Replace LiquidFuel mode by LqdAmmonia mode
+
+@PART[*]:HAS[@MODULE[ModuleEnginesFX]:HAS[#engineID[LF],!PROPELLANT[Oxidizer]],@MODULE[MultiModeEngine]]:NEEDS[!NTRsUseLF]:AFTER[zKerbalAtomics]
+{
+			// cherenkov and nerv thrust is the same on LH2 and LF
+			// althought ammonia mode deserves thrust boost about 20%, KSP-ie would give it 40%
+			// and project rho predicts 100% thrust bonus
+	@MODULE[ModuleEnginesFX]:HAS[#engineID[LF]]
+	{
+		@engineID = Ammonia
+
+		@maxThrust *= 1.7
+		@maxThrust *= #$@SMURFFCONFIG/enginethrustfactor$
+
+		@atmosphereCurve {
+			%_isp = #$/MODULE[ModuleEnginesFX]:HAS[#engineID[LH2]]/atmosphereCurve/key,0[1, ]$
+			@_isp *= 0.6
+			@key,0 = #0 $_isp$
+			@_isp = #$/MODULE[ModuleEnginesFX]:HAS[#engineID[LH2]]/atmosphereCurve/key,1[1, ]$
+			@_isp *= 0.6
+			@key,1 = #1 $_isp$
+			!_isp = 0
+		}
+		@PROPELLANT[LiquidFuel] {
+			@name = LqdAmmonia
+		}
+	}
+	@MODULE[MultiModeEngine]
+	{
+		@primaryEngineID = Ammonia
+		@primaryEngineModeDisplayName = Ammonia
+	}
+	// This one os OK, because we are not adding B9 and LiquidFuel really does not belong in NTR
+}
+
+// Replace LOxAugmented mode by LqdAmmonia mode
+
+@PART[ntr-sc-125-1|ntr-sc-375-1|ntr-sc-25-1]:NEEDS[!NTRsUseLF]:AFTER[zKerbalAtomics]
+{
+	@MODULE[ModuleEnginesFX]:HAS[#engineID[LOxAugmented]]
+	{
+		@engineID = Ammonia
+		@maxThrust = #$/MODULE[ModuleEnginesFX]:HAS[#engineID[LH2]]/maxThrust$
+		@maxThrust *= 1.8
+		@maxThrust *= #$@SMURFFCONFIG/enginethrustfactor$
+		@atmosphereCurve {
+			%_isp = #$/MODULE[ModuleEnginesFX]:HAS[#engineID[LH2]]/atmosphereCurve/key,0[1, ]$
+			@_isp *= 0.6
+			@key,0 = #0 $_isp$
+			@_isp = #$/MODULE[ModuleEnginesFX]:HAS[#engineID[LH2]]/atmosphereCurve/key,1[1, ]$
+			@_isp *= 0.6
+			@key,1 = #1 $_isp$
+			!_isp = 0
+		}
+		@PROPELLANT[LqdHydrogen] {
+			@name = LqdAmmonia
+		}
+		!PROPELLANT[Oxidizer] {}
+	}
+	@MODULE[MultiModeEngine]
+	{
+		@secondaryEngineID = Ammonia
+		@secondaryEngineModeDisplayName = Ammonia
+	}
+}
+
+// Add a LqdAmmonia mode
+
+@PART[ntr-gc-25-2]:NEEDS[!NTRsUseLF]:AFTER[zKerbalAtomics]
+{
+	@MODULE[ModuleEnginesFX]:HAS[@PROPELLANT[LqdHydrogen]]
+	{
+		%engineID = LH2
+	}
+	$MODULE[ModuleEnginesFX]:HAS[#engineID[LH2]]
+	{
+		@engineID = Ammonia
+		@maxThrust *= 1.8
+		@maxThrust *= #$@SMURFFCONFIG/enginethrustfactor$
+		@atmosphereCurve {
+			%_isp = #$key,0[1, ]$
+			@_isp *= 0.6
+			@key,0 = #0 $_isp$
+			@_isp = #$key,1[1, ]$
+			@_isp *= 0.6
+			@key,1 = #1 $_isp$
+			!_isp = 0
+		}
+		@PROPELLANT[LqdHydrogen] {
+			@name = LqdAmmonia
+		}
+	}
+	MODULE
+	{
+		name = MultiModeEngine
+		primaryEngineID = LH2
+		secondaryEngineID = Ammonia
+		primaryEngineModeDisplayName = #LOC_KerbalAtomics_Multimode_LH2
+		secondaryEngineModeDisplayName = Ammonia
+	}
+}

--- a/Extras/ChickenAtomics/ChickenAtomics.md
+++ b/Extras/ChickenAtomics/ChickenAtomics.md
@@ -1,0 +1,24 @@
+Chicken Gas Nuclear Thermal Rockets
+=========
+
+This patchset allows using liquid ammonia in NTRs. Dennis Nikitaev predicts
+that ammonia propellant would result in 2x more thrust at 41% Isp. KSP-IE uses
+1.4x thrust and 63% Isp. As a compromise, this patchset uses 1.7-1.8x thrust
+and 60% Isp.
+
+All multimode ntrs featuring LH2/LF switching are converted to LH2/NH3. Some
+LA-NTRs are stripped of their oxidizer augmented mode and given NH3 modes
+instead. And the Deliverance lightbulb rocket has been extended with ammonia
+mode. The two later patches can be easily extended to other engines if desired.
+
+Lastly, Ammonia configuration has been added to procedural liquid tank.
+
+Due to incompatibility of ModuleSystemHeatFissionEngine with B9 based fuel
+switching, more than two modes can't be added and in-flight switching can't be
+disabled.
+
+Requires: CRP, CryoTanks.
+
+Recommends: Procedural Parts, Rational Resources.
+
+Supports: SMURFF.


### PR DESCRIPTION
This patchset allows using liquid ammonia in NTRs at 180% thrust and 60% Isp.